### PR TITLE
refactor: remove console.log in contract

### DIFF
--- a/packages/contract/contracts/Web3Mint.sol
+++ b/packages/contract/contracts/Web3Mint.sol
@@ -6,7 +6,6 @@ import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import '@openzeppelin/contracts/utils/Counters.sol';
 
 import './libraries/Base64.sol';
-import 'hardhat/console.sol';
 
 contract Web3Mint is ERC721 {
   struct NftAttributes {
@@ -20,9 +19,7 @@ contract Web3Mint is ERC721 {
   // tokenIdはNFTの一意な識別子で、0, 1, 2, .. N のように付与されます。
   Counters.Counter private _tokenIds;
 
-  constructor() ERC721('NFT', 'nft') {
-    console.log('This is my NFT contract.');
-  }
+  constructor() ERC721('NFT', 'nft') {}
 
   // ユーザーが NFT を取得するために実行する関数です。
 
@@ -30,7 +27,6 @@ contract Web3Mint is ERC721 {
     uint256 newItemId = _tokenIds.current();
     _safeMint(msg.sender, newItemId);
     Web3Nfts.push(NftAttributes({name: name, imageURL: imageURI}));
-    console.log('An NFT w/ ID %s has been minted to %s', newItemId, msg.sender);
     _tokenIds.increment();
   }
 


### PR DESCRIPTION
## 変更内容
コントラクト内に定義されていた`console.log`を削除しました。

以下は`yarn contract test`を実行した際の出力結果です。

### 修正前
![Screenshot 2023-11-25 at 18 31 41](https://github.com/unchain-tech/ETH-NFT-Maker/assets/60546319/f9698914-bf92-4aee-bda9-1eb704c148f9)

### 修正後
![Screenshot 2023-11-25 at 18 26 54](https://github.com/unchain-tech/ETH-NFT-Maker/assets/60546319/46de0e45-11ff-4952-b328-0c26c81b3f6f)
